### PR TITLE
Fix text + add note property

### DIFF
--- a/src/cljs/coffee_re_frame/recipe.cljs
+++ b/src/cljs/coffee_re_frame/recipe.cljs
@@ -33,7 +33,7 @@
 (s/def ::recipe (s/keys :req [::name ::steps]))
 
 (defn create-v60-recipe [total-volume]
-  (let [coffee-weight (js/Math.round (/ total-volume 16))]
+  (let [coffee-weight (js/Math.floor (* total-volume 0.06))]
     {::name "Hario v60"
      ::steps [{:step/type :step.type/start
                :step/title "Prepare"
@@ -45,7 +45,7 @@
 
               {:step/type :step.type/prompt
                :step/title "Wet grounds"
-               :step/description (str "Add " coffee-weight "g coffee to the filter and use your finger to create a small hole in the center of the coffee. Then add 60g of water and immediately swirl until all ground are wet.")
+               :step/description (str "Add " coffee-weight "g coffee to the filter and use your finger to create a small hole in the center of the coffee. Then add " (* coffee-weight 2) "g of water and immediately swirl until all ground are wet.")
                :step/volume (* total-volume (/ 30 250))}
 
               {:step/type :step.type/fixed

--- a/src/cljs/coffee_re_frame/recipe.cljs
+++ b/src/cljs/coffee_re_frame/recipe.cljs
@@ -46,6 +46,7 @@
               {:step/type :step.type/prompt
                :step/title "Wet grounds"
                :step/description (str "Add " coffee-weight "g coffee to the filter and use your finger to create a small hole in the center of the coffee. Then add " (* coffee-weight 2) "g of water and immediately swirl until all ground are wet.")
+               :step/note (str "A little more water is fine, but don't go above 3 times your grind weight (" (* coffee-weight 3) "g).")
                :step/volume (* total-volume (/ 30 250))}
 
               {:step/type :step.type/fixed

--- a/src/cljs/coffee_re_frame/views.cljs
+++ b/src/cljs/coffee_re_frame/views.cljs
@@ -84,9 +84,9 @@
       (:step/description step)]
      (if (:step/note step)
       [:div {:class "px-4 py-3"}
-        [:p, {:class "italic inline"}
+        [:p {:class "italic inline"}
           "NOTE:\u00A0"]
-        [:p, {:class "inline"}
+        [:p {:class "inline"}
           (:step/note step)
           ]]
       )]))

--- a/src/cljs/coffee_re_frame/views.cljs
+++ b/src/cljs/coffee_re_frame/views.cljs
@@ -81,7 +81,15 @@
       [:h2 {:class "text-xl"}
        (:step/title step)]]
      [:div {:class "px-4 py-3"}
-      (:step/description step)]]))
+      (:step/description step)]
+     (if (:step/note step)
+      [:div {:class "px-4 py-3"}
+        [:p, {:class "italic inline"}
+          "NOTE:\u00A0"]
+        [:p, {:class "inline"}
+          (:step/note step)
+          ]]
+      )]))
 
 (defn liquid-timer []
   (let [state (re-frame/subscribe [::subs/recipe-state])


### PR DESCRIPTION
- Adjusts grind weight calculation to be more accurate to the 30 / 500 baseline
- Fixes the bloom text so it shows the correct bloom water amount
- Adds optional `note` property to step, used in the bloom weight step.