### PR TITLE
Alert user of timer about to end

### DIFF
--- a/src/cljs/coffee_re_frame/pages/recipe_brew.cljs
+++ b/src/cljs/coffee_re_frame/pages/recipe_brew.cljs
@@ -15,6 +15,11 @@
     [c/home-button]]
    [recipe-title recipe]])
 
+
+(defn time-alert [seconds]
+  (cond
+    (<= seconds 3) (js/window.navigator.vibrate 100)))
+
 (defn next-step-panel []
   (let [step @(re-frame/subscribe [::engine/current-step])
         next-step @(re-frame/subscribe [::engine/next-step])
@@ -35,6 +40,7 @@
 
        true
        [:div {:class "bg-gray-600 py-3 px-4 text-white flex flex-col w-full rounded"}
+        (time-alert remaining-seconds)
         [c/micro-header (str "Up next in " remaining-seconds)]
         (or (:step/title next-step) "Done")])]))
 


### PR DESCRIPTION
- Uses the `window.Navigator#vibrate` function to alert the user that a timed step is ending