### PR TITLE
Remember last brew setting

### DIFF
--- a/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
+++ b/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
@@ -65,7 +65,7 @@
 
                 [:div {:class "space-y-2"}
                  [c/micro-header "Quick select"]
-                 [:div {:class "flex space-x-2"}
+                 [:div {:class "grid grid-cols-3 gap-2"}
                   (for [[size label] (keep #(if % % nil) [[250 "1 cup"] [500 "2 cups"] last [max-volume "Custom"]])]
                     ^{:key label}
                     [:button {:class "bg-gray-800 rounded py-2 px-4 border border-gray-700"

--- a/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
+++ b/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
@@ -3,7 +3,8 @@
    [re-frame.core :as re-frame]
    [reagent.core :as r]
    [coffee-re-frame.engine :as engine]
-   [coffee-re-frame.components :as c]))
+   [coffee-re-frame.components :as c]
+   [coffee-re-frame.storage :as storage]))
 
 (defn parse-number-event [event]
   (js/parseInt (.. event -target -value)))
@@ -11,7 +12,10 @@
 (defn panel []
   (let [recipe-key @(re-frame/subscribe [::engine/selected-recipe-key])
         state (r/atom {:volume 250})
-        max-volume 1000]
+        max-volume 1000
+        last
+          (let [n (storage/get-item "lastSize")]
+            (if n [(int n) (str n " ml")] nil))]
     (fn []
       (let [volume (:volume @state)]
         [c/container
@@ -62,7 +66,7 @@
                 [:div {:class "space-y-2"}
                  [c/micro-header "Quick select"]
                  [:div {:class "flex space-x-2"}
-                  (for [[size label] [[250 "1 cup"] [500 "2 cups"] [max-volume "Custom"]]]
+                  (for [[size label] (keep #(if % % nil) [[250 "1 cup"] [500 "2 cups"] last [max-volume "Custom"]])]
                     ^{:key label}
                     [:button {:class "bg-gray-800 rounded py-2 px-4 border border-gray-700"
                               :on-click #(swap! state assoc :volume size :custom (= size max-volume))

--- a/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
+++ b/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
@@ -9,13 +9,21 @@
 (defn parse-number-event [event]
   (js/parseInt (.. event -target -value)))
 
+(defn get-last-size [] (let [storedLast (storage/get-item "lastSize")]
+  (if storedLast
+    (let [size (int storedLast)]
+      (cond
+        (< size 1) nil
+        (= size 250) nil
+        (= size 500) nil
+        (> size 1000) nil
+        :else [size (str size " ml")])) nil)))
+
 (defn panel []
   (let [recipe-key @(re-frame/subscribe [::engine/selected-recipe-key])
         state (r/atom {:volume 250})
         max-volume 1000
-        last
-          (let [n (storage/get-item "lastSize")]
-            (if n [(int n) (str n " ml")] nil))]
+        last (get-last-size)]
     (fn []
       (let [volume (:volume @state)]
         [c/container

--- a/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
+++ b/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
@@ -75,4 +75,5 @@
 
                 [:div {:class "pt-4 w-full"}
                  [:a {:href (str  "#/brew/" (name recipe-key) "/" (:volume @state))
-                      :class "bg-blue-500 py-2 px-6 rounded text-center block"} "Next"]]]]))))
+                      :class "bg-blue-500 py-2 px-6 rounded text-center block"
+                      :on-click #(storage/set-item! "lastSize" (:volume @state))} "Next"]]]]))))

--- a/src/cljs/coffee_re_frame/storage.cljs
+++ b/src/cljs/coffee_re_frame/storage.cljs
@@ -1,0 +1,9 @@
+(ns coffee-re-frame.storage)
+
+(defn set-item!
+  [key val]
+  (.setItem (.-localStorage js/window) key val))
+
+(defn get-item
+  [key]
+  (.getItem (.-localStorage js/window) key))


### PR DESCRIPTION
Uses localStorage to remember the previous brew setting

- Adds localStorage helpers
- Read from localStorage on brew setup
- Store volume on start
- Changes buttons to use grid
- Will not show extra button until stored
- Hides button if stored size is < 1, 250, 500, or > 1000

![image](https://user-images.githubusercontent.com/972446/139542157-8e3bdf63-453c-47ec-817b-ba8415f38986.png)
