### PR TITLE
Refactor setup page to use re-frame instead of component local state

### DIFF
--- a/src/cljs/coffee_re_frame/db.cljs
+++ b/src/cljs/coffee_re_frame/db.cljs
@@ -5,7 +5,12 @@
 (def default-db
   {:selected-recipe nil
    :recipes {}
-   :recipe-state nil})
+   :recipe-state nil
+   :recipe-setup {:volume 250
+                  :max-volume 1000
+                  :quick-options [[250 "1 cup"] [500 "2 cups"]]
+                  :last-size nil
+                  :type :normal}})
 
 (def default-recipe-state {:tick 0
                            :step-index 0

--- a/src/cljs/coffee_re_frame/effects.cljs
+++ b/src/cljs/coffee_re_frame/effects.cljs
@@ -19,16 +19,16 @@
  :interval
  (create-timer-handler re-frame/dispatch js/setInterval js/clearInterval))
 
-(defn local-storage-coeffect [coeffects key]
-  (assoc coeffects :local-storage
-         (let [result (js->clj (.parse js/JSON (.getItem js/localStorage (name key))))]
+(defn local-storage-coeffect [coeffects [name-key storage-key]]
+  (assoc coeffects name-key
+         (let [result (js->clj (.parse js/JSON (.getItem js/localStorage (name storage-key))))]
            (if (or (map? result) (vector? result))
              (keywordize-keys result)
              result))))
 
 (re-frame/reg-cofx :local-storage local-storage-coeffect)
 
-(defn local-storage-effect [[_ key value]]
+(defn local-storage-effect [[key value]]
   (.setItem js/localStorage (name key) (.stringify js/JSON (clj->js value))))
 
 (re-frame/reg-fx :local-storage local-storage-effect)

--- a/src/cljs/coffee_re_frame/events.cljs
+++ b/src/cljs/coffee_re_frame/events.cljs
@@ -4,12 +4,83 @@
    [day8.re-frame.tracing :refer-macros [fn-traced]]
    [re-frame.core :as re-frame]))
 
-(re-frame/reg-event-db
+(def last-size-key "lastSize")
+
+(re-frame/reg-event-fx
  ::initialize-db
- (fn-traced [_ _]
-            db/default-db))
+ [(re-frame/inject-cofx :local-storage [:last-size last-size-key])]
+ (fn-traced [{:keys [last-size]} _]
+            {:db
+             (cond-> db/default-db
+               true (assoc-in [:recipe-setup :last-size] last-size)
+               (some? last-size) (assoc-in [:recipe-setup :volume] last-size))}))
 
 (re-frame/reg-event-db
  ::set-active-panel
  (fn-traced [db [_ active-panel]]
             (assoc db :active-panel active-panel)))
+
+;; Recipe setup
+
+(defn maybe-set-custom [{:keys [volume max-volume type] :as state}]
+  (if (and (= type :normal) (>= volume max-volume))
+    (-> state
+        (assoc :type :custom))
+    state))
+(defn set-volume [state volume]
+  (assoc state :volume (max 0 volume)))
+
+(defn update-volume [{:keys [volume max-volume type] :as state} new-volume]
+  (-> state
+      (set-volume new-volume)
+      maybe-set-custom))
+
+(re-frame/reg-event-db
+ :recipe-setup/set-volume
+ (fn-traced [db [_ new-volume]]
+            (update db :recipe-setup update-volume new-volume)))
+
+(re-frame/reg-event-db
+ :recipe-setup/increment-volume
+ (fn-traced [db [_ increment]]
+            (let [old-volume (get-in db [:recipe-setup :volume])]
+              (update db :recipe-setup update-volume (+ old-volume increment)))))
+
+(re-frame/reg-event-fx
+ :recipe-setup/save-last-size
+ (fn-traced [{:keys [db]} _]
+            (let [new-last-size (get-in db [:recipe-setup :volume])]
+              {:local-storage [last-size-key new-last-size]
+               :db (assoc-in db [:recipe-setup :last-size] new-last-size)})))
+
+(re-frame/reg-event-db
+ :recipe-setup/make-custom
+ (fn-traced [db _]
+            (assoc-in db [:recipe-setup :type] :custom)))
+
+(re-frame/reg-sub
+ :recipe-setup/volume-type
+ (fn [db _]
+   (get-in db [:recipe-setup :type])))
+
+(re-frame/reg-sub
+ :recipe-setup/volume
+ (fn [db _]
+   (get-in db [:recipe-setup :volume])))
+
+(re-frame/reg-sub
+ :recipe-setup/max-volume
+ (fn [db _]
+   (get-in db [:recipe-setup :max-volume])))
+
+(re-frame/reg-sub
+ :recipe-setup/quick-options
+ (fn [db _]
+   (let [last-size (get-in db [:recipe-setup :last-size])]
+     (cond-> db
+       true (get-in [:recipe-setup :quick-options])
+       (some? last-size) (conj [last-size (str "Last Size (" last-size "ml)")])))))
+
+(comment
+  (re-frame/dispatch [:recipe-setup/increment-volume -50])
+  (re-frame/dispatch [:recipe-setup/set-volume 300]))

--- a/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
+++ b/src/cljs/coffee_re_frame/pages/recipe_setup.cljs
@@ -3,85 +3,73 @@
    [re-frame.core :as re-frame]
    [reagent.core :as r]
    [coffee-re-frame.engine :as engine]
-   [coffee-re-frame.components :as c]
-   [coffee-re-frame.storage :as storage]))
+   [coffee-re-frame.components :as c]))
 
 (defn parse-number-event [event]
   (js/parseInt (.. event -target -value)))
 
-(defn get-last-size [] (let [storedLast (storage/get-item "lastSize")]
-  (if storedLast
-    (let [size (int storedLast)]
-      (cond
-        (< size 1) nil
-        (= size 250) nil
-        (= size 500) nil
-        (> size 1000) nil
-        :else [size (str size " ml")])) nil)))
-
 (defn panel []
   (let [recipe-key @(re-frame/subscribe [::engine/selected-recipe-key])
-        state (r/atom {:volume 250})
-        max-volume 1000
-        last (get-last-size)]
+        volume (re-frame/subscribe [:recipe-setup/volume])
+        volume-type (re-frame/subscribe [:recipe-setup/volume-type])
+        max-volume (re-frame/subscribe [:recipe-setup/max-volume])
+        quick-options (re-frame/subscribe [:recipe-setup/quick-options])]
     (fn []
-      (let [volume (:volume @state)]
+      (let []
         [c/container
                [:form {:class "flex flex-col p-4 space-y-2"}
                 [:div {:class "pb-6"}
                  [c/home-button]]
                 [c/micro-header {:for "volume" :as :label} "How much coffee do you want to make?"]
                 [:div {:class "h-16"}
-                 (if (:custom @state)
+                 (if (= :custom @volume-type)
                    [:input {:id "custom-volume"
                             :class "text-3xl font-bold bg-gray-700 border-none rounded px-2 py-1 w-full"
                             :type :number
-                            :value volume
-                            :on-change #(swap! state assoc :volume (parse-number-event %))}]
+                            :value @volume
+                            :on-change #(re-frame/dispatch [:recipe-setup/set-volume (parse-number-event %)])}]
 
-                   [:p {:class "text-3xl font-bold py-1"} (:volume @state)])
+                   [:p {:class "text-3xl font-bold py-1"} @volume])
                  [:p {:class "text-sm text-gray-500"} "milliliters"]]
                 [:p {:class "italic text-sm text-gray-300"} "250ml is about a cup"]
 
                 [:div {:class "w-full flex flex-row space-x-2"}
                  [:button {:type "button"
                            :class "bg-blue-500 rounded-full w-12 h-12 border border-blue-700 font-bold"
-                           :on-click #(swap! state (fn [s]
-                                                     (assoc s
-                                                            :custom (>= volume max-volume)
-                                                            :volume (- volume 50))))}
-                          "-50"]
+                           :on-click #(re-frame/dispatch [:recipe-setup/increment-volume -50])}
+                  "-50"]
                  [:input {:id "volume"
                           :class "flex-1"
                           :type :range
                           :step 10
                           :min 50
-                          :max max-volume
-                          :value volume
-                          :on-change #(swap! state (fn [s]
-                                                     (let [volume (parse-number-event %)]
-                                                       (assoc s
-                                                              :custom (= volume max-volume)
-                                                              :volume volume))))}]
+                          :max @max-volume
+                          :value @volume
+                          :on-change #(re-frame/dispatch [:recipe-setup/set-volume (parse-number-event %)])}]
                  [:button {:type "button"
                            :class "bg-blue-500 rounded-full w-12 h-12 border border-blue-700 font-bold"
-                           :on-click #(swap! state (fn [s]
-                                                     (assoc s
-                                                            :custom (>= volume max-volume)
-                                                            :volume (+ volume 50))))}
+                           :on-click #(re-frame/dispatch [:recipe-setup/increment-volume 50])}
                           "+50"]]
 
                 [:div {:class "space-y-2"}
                  [c/micro-header "Quick select"]
-                 [:div {:class "grid grid-cols-3 gap-2"}
-                  (for [[size label] (keep #(if % % nil) [[250 "1 cup"] [500 "2 cups"] last [max-volume "Custom"]])]
+                 [:div {:class "grid grid-cols-2 gap-2"}
+                  (for [[size label] @quick-options]
                     ^{:key label}
                     [:button {:class "bg-gray-800 rounded py-2 px-4 border border-gray-700"
-                              :on-click #(swap! state assoc :volume size :custom (= size max-volume))
+                              :on-click #(re-frame/dispatch [:recipe-setup/set-volume size])
                               :type "button"}
-                     label])]]
+                     label])
+
+                  [:button {:class "bg-gray-800 rounded py-2 px-4 border border-gray-700"
+                            :on-click #(re-frame/dispatch [:recipe-setup/make-custom])
+                            :type "button"}
+                   "Custom"]]]
+
+
 
                 [:div {:class "pt-4 w-full"}
-                 [:a {:href (str  "#/brew/" (name recipe-key) "/" (:volume @state))
+                 [:a {:href (str  "#/brew/" (name recipe-key) "/" @volume)
                       :class "bg-blue-500 py-2 px-6 rounded text-center block"
-                      :on-click #(storage/set-item! "lastSize" (:volume @state))} "Next"]]]]))))
+                      :on-click #(re-frame/dispatch [:recipe-setup/save-last-size])}
+                  "Next"]]]]))))

--- a/src/cljs/coffee_re_frame/storage.cljs
+++ b/src/cljs/coffee_re_frame/storage.cljs
@@ -1,9 +1,0 @@
-(ns coffee-re-frame.storage)
-
-(defn set-item!
-  [key val]
-  (.setItem (.-localStorage js/window) key val))
-
-(defn get-item
-  [key]
-  (.getItem (.-localStorage js/window) key))

--- a/test/cljs/coffee_re_frame/effects_test.cljs
+++ b/test/cljs/coffee_re_frame/effects_test.cljs
@@ -6,27 +6,27 @@
   (let [key :my-key]
     (testing "primitives"
       (.clear js/localStorage)
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage nil}))
-      (effects/local-storage-effect [:local-storage key "my value"])
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage "my value"})))
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key nil}))
+      (effects/local-storage-effect [key "my value"])
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key "my value"})))
 
     (testing "vectors"
       (.clear js/localStorage)
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage nil}))
-      (effects/local-storage-effect [:local-storage key [1 2 3]])
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage [1 2 3]})))
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key nil}))
+      (effects/local-storage-effect [key [1 2 3]])
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key [1 2 3]})))
 
     (testing "maps"
       (.clear js/localStorage)
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage nil}))
-      (effects/local-storage-effect [:local-storage key {:key "value" :another "value2"}])
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage {:key "value" :another "value2"}})))
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key nil}))
+      (effects/local-storage-effect [key {:key "value" :another "value2"}])
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key {:key "value" :another "value2"}})))
 
     (testing "nested structures"
       (.clear js/localStorage)
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage nil}))
-      (effects/local-storage-effect [:local-storage key {:a {:nested [{:vector 3}]}}])
-      (is (= (effects/local-storage-coeffect {} key)  {:local-storage {:a {:nested [{:vector 3}]}}})))))
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key nil}))
+      (effects/local-storage-effect [key {:a {:nested [{:vector 3}]}}])
+      (is (= (effects/local-storage-coeffect {} [key key])  {:my-key {:a {:nested [{:vector 3}]}}})))))
 
 (defn setup-interval []
   (let [state (atom {:dispatch [] :setInterval [] :clearInterval []})


### PR DESCRIPTION
Did a big refactor that I've been meaning to get to for a while. Instead of keeping the state for the recipe setup page inside of the component, I moved it up into the global re-frame db and created all the necessary subs/events to interact with it. This should make adding new features much easier in the future :)

* Refactor recipe_setup page to use re-frame state instead of component local state
* Refactor to use local-storage (co)effects
* Default volume is now set to your most recently used volume