### PR TITLE
Add newer V60 recipe

### DIFF
--- a/src/cljs/coffee_re_frame/recipe.cljs
+++ b/src/cljs/coffee_re_frame/recipe.cljs
@@ -45,54 +45,59 @@
                :step/description (str "Boil about " (* 1.5 total-volume) "ml of water. Rinse filter with a generous amount of boiled water. Discard the water.")}
 
               {:step/type :step.type/prompt
-               :step/title "Wet grounds"
-               :step/description (str "Add " coffee-weight "g coffee to the filter and use your finger to create a small hole in the center of the coffee. Then add " (water-portion) "g of water and immediately swirl until all ground are wet.")
-               :step/volume (* total-volume (/ 50 250))}
+               :step/title "Add grounds"
+               :step/description (str "Add " coffee-weight "g coffee to the filter and use your finger to create a small hole in the center of the coffee. ")}
 
               {:step/type :step.type/fixed
-               :step/title "Bloom"
-               :step/description "Wait for coffee to bloom, releasing CO2."
-               :step/duration 30
+               :step/title "Wet grounds"
+               :step/description (str "Gently pour " water-portion "ml of water into the middle of the gounds, spiraling outwards ensuring all grounds are wet.")
+               :step/volume (* total-volume (/ 50 250))
+               :step/duration 15
                :step/timer :start}
 
               {:step/type :step.type/fixed
-               :step/title "First pour"
-               :step/description "Pour water at a strong, even rate, swirling from the center outwards. Water should enter the grounds with force but not splash."
+               :step/title "Bloom"
+               :step/description "Gently swirl the entire countainer to ensure grounds are wet, and wait for coffee to bloom, releasing CO2."
+               :step/duration 30}
+
+              {:step/type :step.type/fixed
+               :step/title "first pour"
+               :step/description "pour water at a strong, even rate, swirling from the center outwards. water should enter the grounds with force but not splash."
                :step/volume (* total-volume (/ 50 250))
-               :step/duration 50}
+               :step/duration 15}
               
-              {:step/type :step.type/prompt
+              {:step/type :step.type/fixed
                :step/title "1st Wait"
                :step/description "Let the coffee rest"
-               :step/duration 15}
+               :step/duration 10}
 
               {:step/type :step.type/fixed
                :step/title "Second pour"
                :step/description "Continue to pour"
                :step/volume (* total-volume (/ 50 250))
-               :step/duration 15}
+               :step/duration 10}
               
-              {:step/type :step.type/prompt
+              {:step/type :step.type/fixed
                :step/title "2nd Wait"
                :step/description "Let the coffee rest"
-               :step/duration 15}
+               :step/duration 10}
               
               {:step/type :step.type/fixed
                :step/title "Third pour"
                :step/description "Continue to pour"
                :step/volume (* total-volume (/ 50 250))
-               :step/duration 15}
+               :step/duration 10}
               
-              {:step/type :step.type/prompt
+              {:step/type :step.type/fixed
                :step/title "3rd Wait"
                :step/description "Let the coffee rest"
-               :step/duration 15}
+               :step/duration 10}
 
               {:step/type :step.type/fixed
                :step/title "Final pour"
                :step/description "Continue to pour"
                :step/volume (* total-volume (/ 50 250))
-               :step/duration 15}
+               :step/duration 10}
 
               {:step/type :step.type/prompt
                :step/title "Stir + swirl"
@@ -160,8 +165,8 @@
                :step/timer :stop}]}))
 
 (def recipe-constructors
-  {:v60 create-v60-recipe}
-  {:v62 create-v60-single-recipe})
+  {:v60-single create-v60-single-recipe
+  :v60 create-v60-recipe})
 
 (defn get-total-volume [recipe]
   (let [steps (::steps recipe)]

--- a/src/cljs/coffee_re_frame/recipe.cljs
+++ b/src/cljs/coffee_re_frame/recipe.cljs
@@ -38,11 +38,11 @@
     {::name "Hario v60"
      ::steps [{:step/type :step.type/start
                :step/title "Prepare"
-               :step/description (str "Grind " coffee-weight "g of coffee, set it aside for later. Place your filter into the v60 brewer.")}
+               :step/description (str "Boil about " (* 2 total-volume) "ml of water. Use some of the water to pre-heat your V60 brewer, without the filter. Grind " coffee-weight "g of coffee, set it aside for later. Place your filter into the v60 brewer.")}
 
               {:step/type :step.type/prompt
                :step/title "Rinse filter"
-               :step/description (str "Boil about " (* 1.5 total-volume) "ml of water. Rinse filter with a generous amount of boiled water. Discard the water.")}
+               :step/description "Rinse filter with a generous amount of boiled water. Discard the water in the filter."}
 
               {:step/type :step.type/prompt
                :step/title "Add grounds"
@@ -123,7 +123,7 @@
 
               {:step/type :step.type/prompt
                :step/title "Rinse filter"
-               :step/description (str "Boil about " (* 1.5 total-volume) "ml of water. Rinse filter with a generous amount of boiled water. Discard the water.")}
+               :step/description (str "Boil about " (* 1.5 total-volume) "ml of water. Rinse filter with a generous amount of boiled water. Discard the water in the filter.")}
 
               {:step/type :step.type/prompt
                :step/title "Wet grounds"

--- a/src/cljs/coffee_re_frame/recipe.cljs
+++ b/src/cljs/coffee_re_frame/recipe.cljs
@@ -32,9 +32,86 @@
 (s/def ::step (s/multi-spec step-type :step/type))
 (s/def ::recipe (s/keys :req [::name ::steps]))
 
+(defn create-v60-single-recipe [total-volume]
+  (let [coffee-weight (js/Math.floor (* total-volume 0.06))]
+    (def water-portion (* coffee-weight (/ 10 3)))
+    {::name "Hario v60"
+     ::steps [{:step/type :step.type/start
+               :step/title "Prepare"
+               :step/description (str "Grind " coffee-weight "g of coffee, set it aside for later. Place your filter into the v60 brewer.")}
+
+              {:step/type :step.type/prompt
+               :step/title "Rinse filter"
+               :step/description (str "Boil about " (* 1.5 total-volume) "ml of water. Rinse filter with a generous amount of boiled water. Discard the water.")}
+
+              {:step/type :step.type/prompt
+               :step/title "Wet grounds"
+               :step/description (str "Add " coffee-weight "g coffee to the filter and use your finger to create a small hole in the center of the coffee. Then add " (water-portion) "g of water and immediately swirl until all ground are wet.")
+               :step/volume (* total-volume (/ 50 250))}
+
+              {:step/type :step.type/fixed
+               :step/title "Bloom"
+               :step/description "Wait for coffee to bloom, releasing CO2."
+               :step/duration 30
+               :step/timer :start}
+
+              {:step/type :step.type/fixed
+               :step/title "First pour"
+               :step/description "Pour water at a strong, even rate, swirling from the center outwards. Water should enter the grounds with force but not splash."
+               :step/volume (* total-volume (/ 50 250))
+               :step/duration 50}
+              
+              {:step/type :step.type/prompt
+               :step/title "1st Wait"
+               :step/description "Let the coffee rest"
+               :step/duration 15}
+
+              {:step/type :step.type/fixed
+               :step/title "Second pour"
+               :step/description "Continue to pour"
+               :step/volume (* total-volume (/ 50 250))
+               :step/duration 15}
+              
+              {:step/type :step.type/prompt
+               :step/title "2nd Wait"
+               :step/description "Let the coffee rest"
+               :step/duration 15}
+              
+              {:step/type :step.type/fixed
+               :step/title "Third pour"
+               :step/description "Continue to pour"
+               :step/volume (* total-volume (/ 50 250))
+               :step/duration 15}
+              
+              {:step/type :step.type/prompt
+               :step/title "3rd Wait"
+               :step/description "Let the coffee rest"
+               :step/duration 15}
+
+              {:step/type :step.type/fixed
+               :step/title "Final pour"
+               :step/description "Continue to pour"
+               :step/volume (* total-volume (/ 50 250))
+               :step/duration 15}
+
+              {:step/type :step.type/prompt
+               :step/title "Stir + swirl"
+               :step/description "Stir coffee and grounds with a spoon one turn in both directions, avoiding long-lasting swirling. Then pick up vessel and brewer and gently swirl several times."}
+
+              {:step/type :step.type/prompt
+               :step/title "Draw-down"
+               :step/display :step.display/time
+               :step/description "Wait for water level to meet the top of the grounds."}
+
+              {:step/type :step.type/end
+               :step/title "Enjoy"
+               :step/description "Discard coffee grounds and enjoy."
+               :step/display :step.display/time
+               :step/timer :stop}]}))
+
 (defn create-v60-recipe [total-volume]
   (let [coffee-weight (js/Math.floor (* total-volume 0.06))]
-    {::name "Hario v60"
+    {::name "Hario v60 (Multi-Cup)"
      ::steps [{:step/type :step.type/start
                :step/title "Prepare"
                :step/description (str "Grind " coffee-weight "g of coffee, set it aside for later. Place your filter into the v60 brewer.")}
@@ -83,7 +160,8 @@
                :step/timer :stop}]}))
 
 (def recipe-constructors
-  {:v60 create-v60-recipe})
+  {:v60 create-v60-recipe}
+  {:v62 create-v60-single-recipe})
 
 (defn get-total-volume [recipe]
   (let [steps (::steps recipe)]


### PR DESCRIPTION
- Adds James Hoffman's new single-cup V60 brew method ([video](https://www.youtube.com/watch?v=1oB1oDrDkHM))
```
(For a 250ml brew)
0m00s: Pour 50g of water to bloom
0m10s - 0m15s: Gently Swirl
0m00s - 0m45s: Bloom
0m45s - 1m00s: Pour up to 100g total (40% total weight)
1m00s - 1m10s: Pause
1m10s - 1m20s: Pour up to 150g total (60% total weight)
1m20s - 1m30s: Pause
1m30s - 1m40s: Pour up to 200g total (80% total weight)
1m40s - 1m50s: Pause
1m50s - 2m00s: Pour up to 250g total (100% total weight)
2m00s - 2m05s: Gently swirl
```
- Renames the existing V60 method to `Hario v60 (Multi-Cup)`